### PR TITLE
Update widget tests

### DIFF
--- a/lib/src/widgets/headline.dart
+++ b/lib/src/widgets/headline.dart
@@ -1,12 +1,13 @@
 import 'package:flutter/material.dart';
 
 const Duration headlineAnimationDuration = const Duration(milliseconds: 600);
+const List<Color> headlineTextColors = [Colors.blue, Colors.deepOrange];
 
 class Headline extends ImplicitlyAnimatedWidget {
   final String text;
   final int index;
 
-  Color get targetColor => index == 0 ? Colors.blue : Colors.deepOrange;
+  Color get targetColor => headlineTextColors[index];
 
   Headline({@required this.text, @required this.index, Key key})
       : super(key: key, duration: headlineAnimationDuration);

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -53,5 +53,58 @@ void main() {
     await tester.tap(find.byKey(buttonKey));
 
     await tester.pumpAndSettle();
+
+    expect(find.text('Bar'), findsOneWidget);
+  });
+
+  testWidgets('headline animates and changes text color correctly',
+      (WidgetTester tester) async {
+    String text = "Foo";
+    int index = 0;
+    Key buttonKey = GlobalKey();
+    Key headlineKey = GlobalKey();
+    Headline headline;
+
+    Widget widget = StatefulBuilder(
+      builder: (BuildContext context, void Function(void Function()) setState) {
+        headline = Headline(
+          key: headlineKey,
+          text: text,
+          index: index,
+        );
+
+        return Directionality(
+          textDirection: TextDirection.ltr,
+          child: Column(
+            children: <Widget>[
+              headline,
+              FlatButton(
+                onPressed: () {
+                  setState(() {
+                    text = 'Bar';
+                    index = 1;
+                  });
+                },
+                child: Text("Tap"),
+                key: buttonKey,
+              )
+            ],
+          ),
+        );
+      },
+    );
+    await tester.pumpWidget(
+      widget,
+    );
+
+    expect(headline.targetColor, headlineTextColors[index]);
+
+    await tester.pump();
+
+    await tester.tap(find.byKey(buttonKey));
+
+    await tester.pumpAndSettle();
+
+    expect(headline.targetColor, headlineTextColors[index]);
   });
 }


### PR DESCRIPTION
The widget test for testing headline text change was not actually checking the text change. A second assertion has been added to confirm if the text actually changed from Foo to Bar. 

Another test to verify color change has been added as well.