### PR TITLE
Alternative widget test implementation with streams

### DIFF
--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -4,6 +4,8 @@
 // find child widgets in the widget tree, read text, and verify that the values of widget properties
 // are correct.
 // import 'dart:async';
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hn_app/src/widgets/headline.dart';
@@ -11,100 +13,63 @@ import 'package:hn_app/src/widgets/headline.dart';
 void main() {
   testWidgets('headline animates and changes text correctly',
       (WidgetTester tester) async {
-    String text = "Foo";
-    int index = 0;
-    Key buttonKey = GlobalKey();
-    Key headlineKey = GlobalKey();
+    final controller = StreamController<String>();
 
-    Widget widget = StatefulBuilder(
-      builder: (BuildContext context, void Function(void Function()) setState) {
-        return Directionality(
-          textDirection: TextDirection.ltr,
-          child: Column(
-            children: <Widget>[
-              Headline(
-                key: headlineKey,
-                text: text,
-                index: index,
-              ),
-              FlatButton(
-                onPressed: () {
-                  setState(() {
-                    text = 'Bar';
-                    index = 1;
-                  });
-                },
-                child: Text("Tap"),
-                key: buttonKey,
-              )
-            ],
+    Widget widget = StreamBuilder(
+      stream: controller.stream,
+      initialData: 'Foo',
+      builder: (context, snapshot) => Directionality(
+            textDirection: TextDirection.ltr,
+            child: Headline(
+              text: snapshot.data,
+              index: 0,
+            ),
           ),
-        );
-      },
     );
-    await tester.pumpWidget(
-      widget,
-    );
+
+    await tester.pumpWidget(widget);
 
     expect(find.text('Foo'), findsOneWidget);
 
-    await tester.pump();
-
-    await tester.tap(find.byKey(buttonKey));
+    controller.add('Bar');
 
     await tester.pumpAndSettle();
 
     expect(find.text('Bar'), findsOneWidget);
+
+    controller.close();
   });
 
   testWidgets('headline animates and changes text color correctly',
       (WidgetTester tester) async {
-    String text = "Foo";
-    int index = 0;
-    Key buttonKey = GlobalKey();
-    Key headlineKey = GlobalKey();
+    final controller = StreamController<int>();
+
     Headline headline;
-
-    Widget widget = StatefulBuilder(
-      builder: (BuildContext context, void Function(void Function()) setState) {
+    Widget widget = StreamBuilder(
+      stream: controller.stream,
+      initialData: 0,
+      builder: (context, snapshot) {
         headline = Headline(
-          key: headlineKey,
-          text: text,
-          index: index,
+          text: 'Foo',
+          index: snapshot.data,
         );
-
         return Directionality(
           textDirection: TextDirection.ltr,
-          child: Column(
-            children: <Widget>[
-              headline,
-              FlatButton(
-                onPressed: () {
-                  setState(() {
-                    text = 'Bar';
-                    index = 1;
-                  });
-                },
-                child: Text("Tap"),
-                key: buttonKey,
-              )
-            ],
-          ),
+          child: headline,
         );
       },
     );
-    await tester.pumpWidget(
-      widget,
-    );
 
-    expect(headline.targetColor, headlineTextColors[index]);
+    await tester.pumpWidget(widget);
 
-    await tester.pump();
+    expect(headline.targetColor, headlineTextColors[0]);
 
-    await tester.tap(find.byKey(buttonKey));
+    controller.add(1);
 
     await tester.pumpAndSettle();
 
-    expect(headline.targetColor, headlineTextColors[index]);
+    expect(headline.targetColor, headlineTextColors[1]);
+
+    controller.close();
   });
 }


### PR DESCRIPTION
This PR shows how to test an implicitly animated widget using a stream builder.

The key difference between this and what was done during the boring show is here we provide the stream builder initial value.