### PR TITLE
Added fetch stories task and deprecated worker.

### DIFF
--- a/lib/src/notifiers/fetch_stories.dart
+++ b/lib/src/notifiers/fetch_stories.dart
@@ -1,0 +1,105 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:built_value/serializer.dart';
+import 'package:executorservices/executorservices.dart';
+import 'package:hn_app/src/article.dart';
+import 'package:hn_app/src/notifiers/hn_api.dart';
+import 'package:http/http.dart' as http;
+
+class FetchStories extends Task<List<Article>> {
+  static const _baseUrl = 'https://hacker-news.firebaseio.com/v0/';
+
+  /// [_httpClient] can be passed, which allow us to switch the client in tests.
+  FetchStories(
+    StoriesType type, {
+    http.Client networkClient,
+    Map<int, Article> cachedArticles,
+  })  : _url = _getIdsFullUrl(type),
+        _httpClient = networkClient ?? http.Client(),
+        _cachedArticles = cachedArticles;
+
+  final String _url;
+
+  final http.Client _httpClient;
+
+  final Map<int, Article> _cachedArticles;
+
+  @override
+  FutureOr<List<Article>> execute() async {
+    final articleIds = await _getIds(_url);
+
+    final articles = await _getArticles(articleIds);
+
+    return articles;
+  }
+
+  Future<List<Article>> _getArticles(List<int> articleIds) async {
+    final results = <Article>[];
+
+    // We are running the fetch of each article in parallel with Future.wait.
+    // Here, we catch HackerNewsApiExceptions so that one API exception
+    // doesn't stop the whole fetch.
+    var futureArticles = articleIds.map<Future<void>>((id) async {
+      try {
+        var article = await _getArticle(id);
+        results.add(article);
+      } on HackerNewsApiException catch (e) {
+        print(e);
+      }
+    });
+    await Future.wait(futureArticles);
+    var filtered = results.where((a) => a.title != null).toList();
+    // Re-sort the articles according to the original order in [articleIds].
+    // We need to do this because fetching the articles in parallel will
+    // result in scrambled order.
+    filtered.sort(
+        (a, b) => articleIds.indexOf(a.id).compareTo(articleIds.indexOf(b.id)));
+    return filtered;
+  }
+
+  Future<Article> _getArticle(int id) async {
+    if (!_cachedArticles.containsKey(id)) {
+      var storyUrl = '${_baseUrl}item/$id.json';
+      try {
+        var storyRes = await _httpClient.get(storyUrl);
+        if (storyRes.statusCode == 200 && storyRes.body != null) {
+          return parseArticle(storyRes.body);
+        } else {
+          throw HackerNewsApiException(statusCode: storyRes.statusCode);
+        }
+      } on DeserializationError {
+        throw HackerNewsApiException(
+          statusCode: 200,
+          message: "Article was not parseable.",
+        );
+      } on http.ClientException {
+        throw HackerNewsApiException(message: "Connection failed.");
+      }
+    }
+
+    print("Founded article with id $id in the catch");
+
+    return _cachedArticles[id];
+  }
+
+  Future<List<int>> _getIds(String url) async {
+    http.Response response;
+    try {
+      response = await _httpClient.get(url);
+    } on SocketException catch (e) {
+      throw HackerNewsApiError("$url couldn't be fetched: $e");
+    }
+    if (response.statusCode != 200) {
+      throw HackerNewsApiError("$url returned non-HTTP200");
+    }
+
+    var result = parseStoryIds(response.body);
+
+    return result.take(10).toList();
+  }
+
+  static String _getIdsFullUrl(StoriesType type) {
+    return '$_baseUrl${type == StoriesType.topStories ? 'top' : 'new'}stories.json';
+  }
+}

--- a/lib/src/notifiers/hn_api.dart
+++ b/lib/src/notifiers/hn_api.dart
@@ -81,20 +81,15 @@ class HackerNewsTab with ChangeNotifier {
     notifyListeners();
     loadingTabsCount.value += 1;
 
-    try {
-      final refreshedArticles = await executorService.submit(
-        FetchStories(storiesType, cachedArticles: _cachedArticles),
-      );
+    final refreshedArticles = await executorService.submit(
+      FetchStories(storiesType, cachedArticles: _cachedArticles),
+    );
 
-      for (final article in refreshedArticles) {
-        _cachedArticles[article.id] = article;
-      }
-
-      _articles = refreshedArticles;
-    } on HackerNewsApiException catch (error) {
-      //TODO do something with the error
-
+    for (final article in refreshedArticles) {
+      _cachedArticles[article.id] = article;
     }
+
+    _articles = refreshedArticles;
 
     // TODO: remove the artificial delay, or don't wait if the actual fetch
     //       has taken enough time

--- a/lib/src/notifiers/hn_api.dart
+++ b/lib/src/notifiers/hn_api.dart
@@ -1,10 +1,19 @@
 import 'dart:async';
 import 'dart:collection';
 
+import 'package:executorservices/executorservices.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:hn_app/src/article.dart';
-import 'package:hn_app/src/notifiers/worker.dart';
+import 'package:hn_app/src/notifiers/fetch_stories.dart';
+
+Map<int, Article> _cachedArticles = {};
+
+/// Executor are lazily created so if one isolate can handle all
+/// of the tasks, it's will be reused.
+final executorService = ExecutorService.newFixedExecutor(
+  StoriesType.values.length,
+);
 
 class HackerNewsApiError extends Error {
   final String message;
@@ -56,6 +65,7 @@ class HackerNewsTab with ChangeNotifier {
   List<Article> _articles = [];
 
   bool _isLoading = false;
+
   bool get isLoading => _isLoading;
 
   final IconData icon;
@@ -71,13 +81,20 @@ class HackerNewsTab with ChangeNotifier {
     notifyListeners();
     loadingTabsCount.value += 1;
 
-    final worker = Worker();
-    await worker.isReady;
+    try {
+      final refreshedArticles = await executorService.submit(
+        FetchStories(storiesType, cachedArticles: _cachedArticles),
+      );
 
-    _articles = await worker.fetch(storiesType);
-    _isLoading = false;
+      for (final article in refreshedArticles) {
+        _cachedArticles[article.id] = article;
+      }
 
-    worker.dispose();
+      _articles = refreshedArticles;
+    } on HackerNewsApiException catch (error) {
+      //TODO do something with the error
+
+    }
 
     // TODO: remove the artificial delay, or don't wait if the actual fetch
     //       has taken enough time

--- a/lib/src/notifiers/worker.dart
+++ b/lib/src/notifiers/worker.dart
@@ -7,7 +7,6 @@ import 'package:hn_app/src/article.dart';
 import 'package:hn_app/src/notifiers/hn_api.dart';
 import 'package:http/http.dart' as http;
 
-@Deprecated("Use the new FetchStories task")
 class Worker {
   static const _baseUrl = 'https://hacker-news.firebaseio.com/v0/';
 

--- a/lib/src/notifiers/worker.dart
+++ b/lib/src/notifiers/worker.dart
@@ -7,6 +7,7 @@ import 'package:hn_app/src/article.dart';
 import 'package:hn_app/src/notifiers/hn_api.dart';
 import 'package:http/http.dart' as http;
 
+@Deprecated("Use the new FetchStories task")
 class Worker {
   static const _baseUrl = 'https://hacker-news.firebaseio.com/v0/';
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -28,14 +28,14 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.2.0"
+    version: "2.3.0"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.4"
+    version: "1.0.5"
   build:
     dependency: transitive
     description:
@@ -155,6 +155,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.2.7"
+  executorservices:
+    dependency: "direct main"
+    description:
+      name: executorservices
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.5"
   fixnum:
     dependency: transitive
     description:
@@ -283,7 +290,7 @@ packages:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.6"
+    version: "1.1.7"
   mime:
     dependency: transitive
     description:
@@ -346,14 +353,14 @@ packages:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.6.2"
+    version: "1.6.4"
   pedantic:
     dependency: transitive
     description:
       name: pedantic
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.0"
+    version: "1.8.0+1"
   pool:
     dependency: transitive
     description:
@@ -388,7 +395,7 @@ packages:
       name: quiver
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.3"
+    version: "2.0.5"
   recase:
     dependency: transitive
     description:
@@ -498,7 +505,7 @@ packages:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.4"
+    version: "1.0.5"
   synchronized:
     dependency: transitive
     description:
@@ -598,5 +605,5 @@ packages:
     source: hosted
     version: "2.1.15"
 sdks:
-  dart: ">=2.3.0-dev.0.5.flutter-a1668566e5 <3.0.0"
+  dart: ">=2.4.0 <3.0.0"
   flutter: ">=1.2.1 <2.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -28,6 +28,8 @@ dependencies:
 
   shared_preferences: ^0.5.2+1
 
+  executorservices: ^1.0.5
+
 dev_dependencies:
   build_runner: ^1.4.0
   built_value_generator: ^6.5.0


### PR DESCRIPTION
So i was rewatching the boring show episode Isolates and multithreading in Flutter Part 2

I saw that we had to take many decision just because passing data between isolate it's difficult, ex: we had to get ride of the memory caching map.

What if we could write code and don't care about isolates ?

So i refactored the code so that it would use the executorservices package
https://pub.dev/packages/executorservices

And it's was so easy that it's only took me 5 minutes to move the code and re-add removed memory cache.